### PR TITLE
FIX undefined offset when methods have default parameters

### DIFF
--- a/src/Kdyby/Aop/PhpGenerator/PointcutMethod.php
+++ b/src/Kdyby/Aop/PhpGenerator/PointcutMethod.php
@@ -142,12 +142,7 @@ class PointcutMethod extends Code\Method
 		}
 
 		if (!$this->around) {
-			$argumentsPass = array();
-			foreach (array_values($this->getParameters()) as $i => $parameter) {
-				$argumentsPass[] = '$__arguments[' . $i . ']';
-			}
-			$parentCall = Code\Helpers::format('$__result = parent::?(?);', $this->getName(), new Code\PhpLiteral(implode(', ', $argumentsPass)));
-
+			$parentCall = Code\Helpers::format('$__result = call_user_func_array("parent::?", $__arguments);', $this->getName());
 		} else {
 			$parentCall = Code\Helpers::format('$__around = new \Kdyby\Aop\JoinPoint\AroundMethod($this, __FUNCTION__, $__arguments);');
 			foreach ($this->around as $around) {


### PR DESCRIPTION
This should fix the problem with default parameters

But this works only for PHP 5.3+

[Fixes #9]
