### PR TITLE
ServiceDefinition: getOpenMethods returns leaf definitions

### DIFF
--- a/src/Kdyby/Aop/Pointcut/ServiceDefinition.php
+++ b/src/Kdyby/Aop/Pointcut/ServiceDefinition.php
@@ -120,7 +120,9 @@ class ServiceDefinition extends Nette\Object
 					continue; // todo: maybe in next version
 				}
 
-				$this->openMethods[$method->getName()] = new Method($method, $this);
+				if (!isset($this->openMethods[$method->getName()])) {
+					$this->openMethods[$method->getName()] = new Method($method, $this);
+				}
 			}
 
 		} while ($type = $type->getParentClass());

--- a/tests/KdybyTests/Aop/ServiceDefinition.phpt
+++ b/tests/KdybyTests/Aop/ServiceDefinition.phpt
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * Test: Kdyby\Aop\PointcutRules.
+ *
+ * @testCase KdybyTests\Aop\PointcutRulesTest
+ * @author Filip Procházka <filip@prochazka.su>
+ * @package Kdyby\Aop
+ */
+
+namespace KdybyTests\Aop;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Kdyby;
+use Kdyby\Aop\Pointcut;
+use Kdyby\Aop\Pointcut\Matcher;
+use Kdyby\Aop\Pointcut\Matcher\Criteria;
+use Kdyby\Aop\Pointcut\Matcher\SettingMatcher;
+use Nette;
+use Nette\PhpGenerator as Code;
+use Tester;
+use Tester\Assert;
+
+require_once __DIR__ . '/../bootstrap.php';
+require_once __DIR__ . '/files/pointcut-examples.php';
+
+
+
+/**
+ * @author Karel Hak <karel.hak@fregis.cz>
+ */
+class ServiceDefinitionTest extends Tester\TestCase
+{
+
+	public function testInheritedConstructor()
+	{
+		$definition = $this->createDefinition('KdybyTests\Aop\InheritedClass');
+		Assert::equal($definition->getOpenMethods(), array('__construct' => new Pointcut\Method(\Nette\Reflection\Method::from('KdybyTests\Aop\InheritedClass', '__construct'), $definition)));
+	}
+
+
+
+	/**
+	 * @param string $class
+	 * @return Pointcut\ServiceDefinition
+	 */
+	private function createDefinition($class)
+	{
+		$def = new Nette\DI\ServiceDefinition();
+		$def->setClass($class);
+
+		return new Pointcut\ServiceDefinition($def, 'abc');
+	}
+
+}
+
+\run(new ServiceDefinitionTest());

--- a/tests/KdybyTests/Aop/files/pointcut-examples.php
+++ b/tests/KdybyTests/Aop/files/pointcut-examples.php
@@ -185,3 +185,20 @@ class MockPresenter extends Nette\Application\UI\Presenter
 	}
 
 }
+
+class BaseClass
+{
+
+	public function __construct($x) {
+		;
+	}
+}
+
+class InheritedClass extends BaseClass
+{
+
+	public function __construct($x, $y)
+	{
+		parent::__construct($x);
+	}
+}


### PR DESCRIPTION
At this time, its not possible to override __constructor and add some next parameter if advice on constructor exists (it cause an error if new parameter has some typehint, cause aop container is injected instead of parameter). It is because getOpenMethods returns definition from parent class instead of inherited class.

This pull-request fix that.
