### PR TITLE
Enforcing proxy class for constructor only aspect

### DIFF
--- a/src/Kdyby/Aop/DI/AopExtension.php
+++ b/src/Kdyby/Aop/DI/AopExtension.php
@@ -151,6 +151,9 @@ class AopExtension extends Nette\DI\CompilerExtension
 				array_unshift($setup, $statement);
 				$def->setSetup($setup);
 			}
+
+		} else {
+			$def->setClass($def->getFactory()->getEntity());
 		}
 	}
 


### PR DESCRIPTION
This seems to fix proxy class name for constructor only aspect. Without it the class name is not changed in DI service function.
So far this is big WTF for me. Do not merge until you understand what is wrong!
[Example](https://gist.github.com/mishak87/13ea6be081e217de06bb) where it wasn't working.
