### PR TITLE
Fix passing arguments in service definition patching

### DIFF
--- a/src/Kdyby/Aop/DI/AopExtension.php
+++ b/src/Kdyby/Aop/DI/AopExtension.php
@@ -122,8 +122,9 @@ class AopExtension extends Nette\DI\CompilerExtension
 		}
 
 		$def = $this->getContainerBuilder()->getDefinition($serviceId);
-		if ($def->getFactory()) {
-			$def->setFactory(new Nette\DI\Statement($cg->getName() . '\\' . $advisedClass->getName()));
+		$factory = $def->getFactory();
+		if ($factory) {
+			$def->setFactory(new Nette\DI\Statement($cg->getName() . '\\' . $advisedClass->getName(), $factory->arguments));
 
 		} else {
 			$def->setFactory($cg->getName() . '\\' . $advisedClass->getName());


### PR DESCRIPTION
On older versions (compatible with nette 2.3 and php 5.6) this was working normally, so I guess it broke during in compability fixes.

This commit fixes a case, when there is a service, which has some (even partially) manual wiring, eg:

```php
class FooService {
   public function __construct() {
      int $someScalar,
      BarService
   }
}
```

```
services:
    fooService:
        class: FooService(%someScalar%)
```

This was not passing during container compilation, someScalar argument were ommited by aop extension.