### PR TITLE
Support void return type

### DIFF
--- a/src/Kdyby/Aop/PhpGenerator/PointcutMethod.php
+++ b/src/Kdyby/Aop/PhpGenerator/PointcutMethod.php
@@ -224,7 +224,10 @@ class PointcutMethod extends Code\Method
 		if ($this->afterThrowing || $this->after) {
 			$this->addBody('if ($__exception) { throw $__exception; }');
 		}
-		$this->addBody('return $__result;');
+
+		if($this->getReturnType() !== 'void') {
+			$this->addBody('return $__result;');
+		}
 
 		return parent::__toString();
 	}


### PR DESCRIPTION
Fixes
```
Compile Error

A void function must not return a value
```
when function return type is set as void